### PR TITLE
adds Ubuntu LTS releases to supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,12 @@ galaxy_info:
       versions:
         - 7
 
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+        - focal
+
   galaxy_tags:
     - ssh
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,12 +84,16 @@
 
 - name: deploy SSH daemon configuration
   template:
-    src: 'sshd_config_{{ ansible_os_family | lower }}.conf'
+    src: '{{ item }}'
     dest: /etc/ssh/sshd_config
     owner: root
     group: root
     mode: 0644
     validate: /usr/sbin/sshd -t -f %s
+  with_first_found:
+    - files:
+        - 'sshd_config_{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.conf'
+        - 'sshd_config_{{ ansible_os_family | lower }}.conf'
   notify:
     - reload SSH daemon
   tags:

--- a/templates/sshd_config_ubuntu_16.conf
+++ b/templates/sshd_config_ubuntu_16.conf
@@ -1,0 +1,234 @@
+# {{ ansible_managed }}
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+# The default requires explicit activation of protocol 1
+#Protocol 2
+
+# HostKey for protocol version 1
+#HostKey /etc/ssh/ssh_host_key
+# HostKeys for protocol version 2
+{% if ssh_host_keys is defined %}
+{% for key in ssh_host_keys %}
+HostKey {{ key }}
+{% endfor %}
+{% else %}
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+{% endif %}
+{% if ssh_host_key_algorithms is defined %}
+
+HostKeyAlgorithms {{ ssh_host_key_algorithms | join(',') }}
+{% endif %}
+
+# Lifetime and size of ephemeral version 1 server key
+#KeyRegenerationInterval 1h
+#ServerKeyBits 1024
+
+# Ciphers and keying
+#RekeyLimit default none
+{% if ssh_ciphers is defined %}
+Ciphers {{ ssh_ciphers | join(',') }}
+{% endif %}
+{% if ssh_kex_algorithms is defined %}
+KexAlgorithms {{ ssh_kex_algorithms | join(',') }}
+{% endif %}
+{% if ssh_macs is defined %}
+MACs {{ ssh_macs | join(',') }}
+{% endif %}
+
+# Logging
+# obsoletes QuietMode and FascistLogging
+#SyslogFacility AUTH
+{% if ssh_log_level is defined %}
+LogLevel {{ ssh_log_level }}
+{% else %}
+#LogLevel INFO
+{% endif %}
+
+# Authentication:
+
+#LoginGraceTime 2m
+{% if ssh_permit_root_login is defined %}
+PermitRootLogin {{ ssh_permit_root_login }}
+{% else %}
+#PermitRootLogin prohibit-password
+{% endif %}
+{% if ssh_strict_modes is defined %}
+StrictModes {{ ssh_strict_modes | ternary('yes', 'no') }}
+{% else %}
+#StrictModes yes
+{% endif %}
+#MaxAuthTries 6
+#MaxSessions 10
+
+#RSAAuthentication yes
+{% if ssh_pubkey_authentication is defined %}
+PubkeyAuthentication {{ ssh_pubkey_authentication | ternary('yes', 'no') }}
+{% else %}
+#PubkeyAuthentication yes
+{% endif %}
+{% if ssh_pubkey_accepted_key_types is defined %}
+PubkeyAcceptedKeyTypes {{ ssh_pubkey_accepted_key_types | join(',') }}
+{% endif %}
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#RhostsRSAAuthentication no
+# similar for protocol version 2
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# RhostsRSAAuthentication and HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+{% if ssh_password_authentication is defined %}
+PasswordAuthentication {{ ssh_password_authentication | ternary('yes', 'no') }}
+{% else %}
+#PasswordAuthentication yes
+{% endif %}
+{% if ssh_permit_empty_password is defined %}
+PermitEmptyPasswords {{ ssh_permit_empty_password | ternary('yes', 'no') }}
+{% else %}
+#PermitEmptyPasswords no
+{% endif %}
+
+# Change to no to disable s/key passwords
+{% if ssh_challenge_response_authentication is defined %}
+ChallengeResponseAuthentication {{ ssh_challenge_response_authentication | ternary('yes', 'no') }}
+{% else %}
+#ChallengeResponseAuthentication yes
+{% endif %}
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+{% if ssh_gssapi_authentication is defined %}
+GSSAPIAuthentication {{ ssh_gssapi_authentication | ternary('yes', 'no') }}
+{% else %}
+#GSSAPIAuthentication no
+{% endif %}
+{% if ssh_gssapi_cleanup_credentials is defined %}
+GSSAPICleanupCredentials {{ ssh_gssapi_cleanup_credentials | ternary('yes', 'no') }}
+{% else %}
+#GSSAPICleanupCredentials yes
+{% endif %}
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+{% if ssh_agent_forwarding is defined %}
+AllowAgentForwarding {{ ssh_agent_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowAgentForwarding yes
+{% endif %}
+{% if ssh_tcp_forwarding is defined %}
+AllowTcpForwarding {{ ssh_tcp_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowTcpForwarding yes
+{% endif %}
+#GatewayPorts no
+{% if ssh_x11_forwarding is defined %}
+X11Forwarding {{ ssh_x11_forwarding | ternary('yes', 'no') }}
+{% else %}
+#X11Forwarding no
+{% endif %}
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+{% if ssh_banner is defined %}
+Banner {{ ssh_banner }}
+{% else %}
+# no default banner path
+#Banner none
+{% endif %}
+
+{% if ssh_subsystems is defined %}
+{% if ssh_subsystems | length %}
+
+{% for subsystem in ssh_subsystems %}
+Subsystem	{{ subsystem.name }}	{{ subsystem.command }}
+{% endfor %}
+{% endif %}
+{% else %}
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+{% endif %}
+
+{% if ssh_users is defined %}
+{% for user in ssh_users %}
+Match User {{ user.name }}
+{% for key, value in user.settings.items() %}
+        {{ key }} {{ value }}
+{% endfor %}
+{% if user.authorized_keys is defined %}
+        AuthorizedKeysFile /etc/ssh/authorized_keys/{{ user.name }}
+{% endif %}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
+{% else %}
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+{% endif %}

--- a/templates/sshd_config_ubuntu_18.conf
+++ b/templates/sshd_config_ubuntu_18.conf
@@ -1,0 +1,221 @@
+# {{ ansible_managed }}
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+{% if ssh_host_keys is defined %}
+{% for key in ssh_host_keys %}
+HostKey {{ key }}
+{% endfor %}
+{% else %}
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+{% endif %}
+{% if ssh_host_key_algorithms is defined %}
+
+HostKeyAlgorithms {{ ssh_host_key_algorithms | join(',') }}
+{% endif %}
+
+# Ciphers and keying
+#RekeyLimit default none
+{% if ssh_ciphers is defined %}
+Ciphers {{ ssh_ciphers | join(',') }}
+{% endif %}
+{% if ssh_kex_algorithms is defined %}
+KexAlgorithms {{ ssh_kex_algorithms | join(',') }}
+{% endif %}
+{% if ssh_macs is defined %}
+MACs {{ ssh_macs | join(',') }}
+{% endif %}
+
+# Logging
+#SyslogFacility AUTH
+{% if ssh_log_level is defined %}
+LogLevel {{ ssh_log_level }}
+{% else %}
+#LogLevel INFO
+{% endif %}
+
+# Authentication:
+
+#LoginGraceTime 2m
+{% if ssh_permit_root_login is defined %}
+PermitRootLogin {{ ssh_permit_root_login }}
+{% else %}
+#PermitRootLogin prohibit-password
+{% endif %}
+{% if ssh_strict_modes is defined %}
+StrictModes {{ ssh_strict_modes | ternary('yes', 'no') }}
+{% else %}
+#StrictModes yes
+{% endif %}
+#MaxAuthTries 6
+#MaxSessions 10
+
+{% if ssh_pubkey_authentication is defined %}
+PubkeyAuthentication {{ ssh_pubkey_authentication | ternary('yes', 'no') }}
+{% else %}
+#PubkeyAuthentication yes
+{% endif %}
+{% if ssh_pubkey_accepted_key_types is defined %}
+PubkeyAcceptedKeyTypes {{ ssh_pubkey_accepted_key_types | join(',') }}
+{% endif %}
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+{% if ssh_password_authentication is defined %}
+PasswordAuthentication {{ ssh_password_authentication | ternary('yes', 'no') }}
+{% else %}
+#PasswordAuthentication yes
+{% endif %}
+{% if ssh_permit_empty_password is defined %}
+PermitEmptyPasswords {{ ssh_permit_empty_password | ternary('yes', 'no') }}
+{% else %}
+#PermitEmptyPasswords no
+{% endif %}
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+{% if ssh_challenge_response_authentication is defined %}
+ChallengeResponseAuthentication {{ ssh_challenge_response_authentication | ternary('yes', 'no') }}
+{% else %}
+ChallengeResponseAuthentication no
+{% endif %}
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+{% if ssh_gssapi_authentication is defined %}
+GSSAPIAuthentication {{ ssh_gssapi_authentication | ternary('yes', 'no') }}
+{% else %}
+#GSSAPIAuthentication no
+{% endif %}
+{% if ssh_gssapi_cleanup_credentials is defined %}
+GSSAPICleanupCredentials {{ ssh_gssapi_cleanup_credentials | ternary('yes', 'no') }}
+{% else %}
+#GSSAPICleanupCredentials yes
+{% endif %}
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+{% if ssh_agent_forwarding is defined %}
+AllowAgentForwarding {{ ssh_agent_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowAgentForwarding yes
+{% endif %}
+{% if ssh_tcp_forwarding is defined %}
+AllowTcpForwarding {{ ssh_tcp_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowTcpForwarding yes
+{% endif %}
+#GatewayPorts no
+{% if ssh_x11_forwarding is defined %}
+X11Forwarding {{ ssh_x11_forwarding | ternary('yes', 'no') }}
+{% else %}
+X11Forwarding yes
+{% endif %}
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+{% if ssh_banner is defined %}
+Banner {{ ssh_banner }}
+{% else %}
+# no default banner path
+#Banner none
+{% endif %}
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+{% if ssh_subsystems is defined %}
+{% if ssh_subsystems | length %}
+
+{% for subsystem in ssh_subsystems %}
+Subsystem	{{ subsystem.name }}	{{ subsystem.command }}
+{% endfor %}
+{% endif %}
+{% else %}
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/ssh/sftp-server
+{% endif %}
+
+{% if ssh_users is defined %}
+{% for user in ssh_users %}
+Match User {{ user.name }}
+{% for key, value in user.settings.items() %}
+        {{ key }} {{ value }}
+{% endfor %}
+{% if user.authorized_keys is defined %}
+        AuthorizedKeysFile /etc/ssh/authorized_keys/{{ user.name }}
+{% endif %}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
+{% else %}
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+{% endif %}

--- a/templates/sshd_config_ubuntu_20.conf
+++ b/templates/sshd_config_ubuntu_20.conf
@@ -1,0 +1,222 @@
+# {{ ansible_managed }}
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Include /etc/ssh/sshd_config.d/*.conf
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+{% if ssh_host_keys is defined %}
+{% for key in ssh_host_keys %}
+HostKey {{ key }}
+{% endfor %}
+{% else %}
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+{% endif %}
+{% if ssh_host_key_algorithms is defined %}
+
+HostKeyAlgorithms {{ ssh_host_key_algorithms | join(',') }}
+{% endif %}
+
+# Ciphers and keying
+#RekeyLimit default none
+{% if ssh_ciphers is defined %}
+Ciphers {{ ssh_ciphers | join(',') }}
+{% endif %}
+{% if ssh_kex_algorithms is defined %}
+KexAlgorithms {{ ssh_kex_algorithms | join(',') }}
+{% endif %}
+{% if ssh_macs is defined %}
+MACs {{ ssh_macs | join(',') }}
+{% endif %}
+
+# Logging
+#SyslogFacility AUTH
+{% if ssh_log_level is defined %}
+LogLevel {{ ssh_log_level }}
+{% else %}
+#LogLevel INFO
+{% endif %}
+
+# Authentication:
+
+#LoginGraceTime 2m
+{% if ssh_permit_root_login is defined %}
+PermitRootLogin {{ ssh_permit_root_login }}
+{% else %}
+#PermitRootLogin prohibit-password
+{% endif %}
+{% if ssh_strict_modes is defined %}
+StrictModes {{ ssh_strict_modes | ternary('yes', 'no') }}
+{% else %}
+#StrictModes yes
+{% endif %}
+#MaxAuthTries 6
+#MaxSessions 10
+
+{% if ssh_pubkey_authentication is defined %}
+PubkeyAuthentication {{ ssh_pubkey_authentication | ternary('yes', 'no') }}
+{% else %}
+#PubkeyAuthentication yes
+{% endif %}
+{% if ssh_pubkey_accepted_key_types is defined %}
+PubkeyAcceptedKeyTypes {{ ssh_pubkey_accepted_key_types | join(',') }}
+{% endif %}
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+{% if ssh_password_authentication is defined %}
+PasswordAuthentication {{ ssh_password_authentication | ternary('yes', 'no') }}
+{% else %}
+#PasswordAuthentication yes
+{% endif %}
+{% if ssh_permit_empty_password is defined %}
+PermitEmptyPasswords {{ ssh_permit_empty_password | ternary('yes', 'no') }}
+{% else %}
+#PermitEmptyPasswords no
+{% endif %}
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+{% if ssh_challenge_response_authentication is defined %}
+ChallengeResponseAuthentication {{ ssh_challenge_response_authentication | ternary('yes', 'no') }}
+{% else %}
+ChallengeResponseAuthentication no
+{% endif %}
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+{% if ssh_gssapi_authentication is defined %}
+GSSAPIAuthentication {{ ssh_gssapi_authentication | ternary('yes', 'no') }}
+{% else %}
+#GSSAPIAuthentication no
+{% endif %}
+{% if ssh_gssapi_cleanup_credentials is defined %}
+GSSAPICleanupCredentials {{ ssh_gssapi_cleanup_credentials | ternary('yes', 'no') }}
+{% else %}
+#GSSAPICleanupCredentials yes
+{% endif %}
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+{% if ssh_agent_forwarding is defined %}
+AllowAgentForwarding {{ ssh_agent_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowAgentForwarding yes
+{% endif %}
+{% if ssh_tcp_forwarding is defined %}
+AllowTcpForwarding {{ ssh_tcp_forwarding | ternary('yes', 'no') }}
+{% else %}
+#AllowTcpForwarding yes
+{% endif %}
+#GatewayPorts no
+{% if ssh_x11_forwarding is defined %}
+X11Forwarding {{ ssh_x11_forwarding | ternary('yes', 'no') }}
+{% else %}
+X11Forwarding yes
+{% endif %}
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+{% if ssh_banner is defined %}
+Banner {{ ssh_banner }}
+{% else %}
+# no default banner path
+#Banner none
+{% endif %}
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+{% if ssh_subsystems is defined %}
+{% if ssh_subsystems | length %}
+
+{% for subsystem in ssh_subsystems %}
+Subsystem	{{ subsystem.name }}	{{ subsystem.command }}
+{% endfor %}
+{% endif %}
+{% else %}
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/ssh/sftp-server
+{% endif %}
+
+{% if ssh_users is defined %}
+{% for user in ssh_users %}
+Match User {{ user.name }}
+{% for key, value in user.settings.items() %}
+        {{ key }} {{ value }}
+{% endfor %}
+{% if user.authorized_keys is defined %}
+        AuthorizedKeysFile /etc/ssh/authorized_keys/{{ user.name }}
+{% endif %}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
+{% else %}
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+{% endif %}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,5 @@
+---
+
+ssh_packages: openssh-server
+
+...


### PR DESCRIPTION
The duplication of templates for redhat/centos was done because `ansible_os_distribution` instead of `ansible_os_family` is required for the ubuntu templates. The latter results in `debian` for ubuntu. To confuse the user completely `ansible_os_family` is the easier choice for the vars file. 

`ansible_distribution_major_version` was used because this gives only `7` for centos and I guess rhel (which might be [wrong](https://github.com/ansible/ansible/issues/50141)). For some reason it gives 16/18/20 for ubuntu, which does not make any sense, but oh well ansible. The arch template has now a little `_na` which can probably be removed with a jinja filter.

An alternative approach could be to use a separate set_fact with more logic.