### PR TITLE
fix whether ssh config should reloaded or not when it changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,8 +109,8 @@
     enabled: yes
     state: >-
       {{
-        __sshd_configuration.changed or __ssh_moduli.changed |
-          default(False) |
+        (__sshd_configuration.changed or __ssh_moduli.changed |
+          default(False)) |
           ternary("reloaded", "started")
       }}
   tags:


### PR DESCRIPTION
Adding extra parenthesis around the whole expressions before
the ternary operator.

Without them, this error would pop up if the config actually changed (ansible version 2.11.6):

```
value of state must be one of: reloaded, restarted, started, stopped, got: True
```

With the extra parenthesis it works as expected.

